### PR TITLE
fix: v0.5.1 コードレビュー指摘修正

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccwire",
   "description": "CC-to-CC communication protocol - enables real-time messaging between Claude Code sessions via MCP",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Chronista Club",
     "url": "https://github.com/chronista-club"

--- a/hooks/check-messages.sh
+++ b/hooks/check-messages.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
-SESSION_NAME="${CCWIRE_SESSION_NAME:-}"
+SESSION_NAME=$(resolve_session_name)
 
 if [ ! -f "$DB_PATH" ]; then
   echo '{}'

--- a/hooks/register.sh
+++ b/hooks/register.sh
@@ -35,7 +35,7 @@ fi
 # 既存の registered_at を保持、なければ現在時刻
 EXISTING_REGISTERED=$(run_sql "SELECT registered_at FROM sessions WHERE name = '${SAFE_NAME}';")
 if [ -n "$EXISTING_REGISTERED" ]; then
-  REGISTERED_AT="$EXISTING_REGISTERED"
+  REGISTERED_AT=$(sql_escape "$EXISTING_REGISTERED")
 else
   REGISTERED_AT="$NOW"
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-plugin-ccwire",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "ccwire - CC間通信プロトコルのMCPサーバー",
   "type": "module",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -211,7 +211,7 @@ function execTmux(...args: string[]): Promise<{ ok: boolean; error?: string }> {
 }
 
 async function notifyViaTmux(tmuxTarget: string, message: string): Promise<void> {
-  await execTmux("send-keys", "-t", tmuxTarget, message);
+  await execTmux("send-keys", "-t", tmuxTarget, "-l", message);
   await Bun.sleep(500);
   await execTmux("send-keys", "-t", tmuxTarget, "Enter");
 }
@@ -731,7 +731,7 @@ server.registerTool("wire_thread", {
       JOIN thread t ON m.reply_to = t.id
       WHERE t.depth < ?
     )
-    SELECT msg.* FROM messages msg
+    SELECT DISTINCT msg.* FROM messages msg
     JOIN thread t ON msg.id = t.id
     ORDER BY msg.timestamp ASC
     LIMIT 500
@@ -771,6 +771,14 @@ server.registerTool("wire_control", {
     text: z.string().optional().describe("action='text' の場合に送信するテキスト"),
   },
 }, async ({ session, action, text }) => {
+  const self = resolveCurrentSession();
+  if (!self) {
+    return {
+      content: [{ type: "text" as const, text: "エラー: セッションが見つかりません。wire_register で登録してください。" }],
+      isError: true,
+    };
+  }
+
   cleanStaleSessions();
 
   const target = db.query<Session, [string]>(`SELECT * FROM sessions WHERE name = ?`).get(session);
@@ -825,7 +833,7 @@ server.registerTool("wire_control", {
       break;
   }
 
-  auditLog("control", resolveCurrentSession(), {
+  auditLog("control", self, {
     target_session: session,
     control_action: action,
     text: text ?? null,


### PR DESCRIPTION
## Summary

v0.5.0 のコードレビューで発見された5件の問題を修正。

- **notifyViaTmux `-l` フラグ追加**: tmux send-keys でリテラルモードを使用し、特殊文字インジェクションを防止
- **wire_control 認可チェック**: 未登録セッションからの tmux 操作を拒否
- **wire_thread SELECT DISTINCT**: 非線形リプライグラフでのメッセージ重複を防止
- **register.sh sql_escape**: `REGISTERED_AT` 値の SQL エスケープ漏れ修正
- **check-messages.sh resolve_session_name()**: 環境変数未設定時に tmux/cwd フォールバックを適用

## Test plan

- [ ] `wire_send` → tmux通知がリテラルモードで送信されることを確認
- [ ] 未登録状態で `wire_control` を呼び出し → エラーが返ることを確認
- [ ] `wire_thread` で reply_to チェーンが重複なく取得できることを確認
- [ ] SessionStart hook で `CCWIRE_SESSION_NAME` 未設定時もセッション名が解決されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)