### PR TITLE
chore: official spec compliance (license, homepage, mcpServers path, CHANGELOG)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,11 +15,7 @@
     "messaging",
     "mcp"
   ],
-  "mcpServers": {
-    "ccwire": {
-      "type": "stdio",
-      "command": "bun",
-      "args": ["run", "${CLAUDE_PLUGIN_ROOT}/src/server.ts"]
-    }
-  }
+  "mcpServers": "${CLAUDE_PLUGIN_ROOT}/.mcp.json",
+  "license": "MIT",
+  "homepage": "https://github.com/chronista-club/claude-plugin-ccwire"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "ccwire": {
       "command": "bun",
-      "args": ["run", "${CLAUDE_PLUGIN_ROOT}/src/server.ts"]
+      "args": [
+        "run",
+        "${CLAUDE_PLUGIN_ROOT}/src/server.ts"
+      ],
+      "type": "stdio"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.4] - 2026-05-02
+
+### Changed
+- Spec compliance pass: separated mcpServers to .mcp.json, added license/homepage fields


### PR DESCRIPTION
claude-extensions skill 公式 spec audit 反映: license field 追加、 homepage 追加、 mcpServers を inline → .mcp.json path 参照に分離 (canonical 化)、 CHANGELOG.md skeleton 追加。