### PR TITLE
fix(plugin.json): mcpServers schema validation error 解消 (v0.9.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccwire",
   "description": "CC-to-CC communication protocol - enables real-time messaging between Claude Code sessions via MCP",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "author": {
     "name": "Chronista Club",
     "url": "https://github.com/chronista-club"
@@ -15,7 +15,6 @@
     "messaging",
     "mcp"
   ],
-  "mcpServers": "${CLAUDE_PLUGIN_ROOT}/.mcp.json",
   "license": "MIT",
   "homepage": "https://github.com/chronista-club/claude-plugin-ccwire"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.9.5] - 2026-05-02
+
+### Fixed
+- `plugin.json` の `mcpServers` field を削除 (string path は公式 spec 不一致、 `mcpServers: Invalid input` で install 失敗)
+- `.mcp.json` は plugin root に存在し Claude Code が auto-discover、 plugin.json での参照は不要
+
+### Note
+- v0.9.4 は published tag だが install 不可、 0.9.5 として fix release
+
 ## [0.9.4] - 2026-05-02
 
 ### Changed


### PR DESCRIPTION
v0.9.4 の string path mcpServers が公式 spec 不一致で install 不可。

team-bucciarati 0.17.2 と同型 fix:
- mcpServers field を plugin.json から削除
- .mcp.json は plugin root で auto-discover される
- 0.9.4 → 0.9.5 (patch fix release)